### PR TITLE
Feature/dropbox chunks logic

### DIFF
--- a/eqp_backup/__manifest__.py
+++ b/eqp_backup/__manifest__.py
@@ -11,7 +11,7 @@
         automated maintenance of the specified quantity of the most recent backups. With EQP Automatic Backup,
         users enjoy a streamlined and user-friendly solution for securing their Odoo data.
     """,
-    "version": "17.0.5.0",
+    "version": "17.0.6.0",
     "category": "Tools",
     "license": "LGPL-3",
     "images": ["static/description/eqp_backup.gif"],

--- a/eqp_backup/views/backup_record_views.xml
+++ b/eqp_backup/views/backup_record_views.xml
@@ -79,6 +79,9 @@
                             <group>
                                 <field name="server_id" domain="[('state', '=', 'confirmed')]" readonly="state!='draft'"
                                        options="{'no_create': True, 'no_create_edit': True}"/>
+                                <field name="server_type" invisible="1"/>
+                                <field name="chunk_size" readonly="state!='draft'" required="server_type=='dropbox'"
+                                       invisible="server_type!='dropbox'"/>
                                 <field name="type" readonly="state != 'draft'"/>
                                 <field name="frequency" readonly="state!='draft'"/>
                                 <label for="backup_lifespan_qty" class="oe_inline"/>


### PR DESCRIPTION
Description:
This PR introduces a new chunked upload logic for Dropbox file uploads, allowing large files to be uploaded in smaller chunks instead of a single request.

Changes & Improvements:
Implemented chunked upload using files_upload_session_start, files_upload_session_append_v2, and files_upload_session_finish.
Added support for configurable chunk sizes (record.chunk_size in MB).
Ensured proper session handling to resume uploads efficiently.
Retained the existing logic for full file uploads when chunking is not required.
